### PR TITLE
Rack App

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,19 @@ validations:
 
 ## Installation
 
-To install, add this line to your application's Gemfile:
+To install, add this line to your application's `Gemfile`:
 
 ```ruby
 gem 'rapporteur'
 ```
 
-And then execute:
+Or, to enable the Rails engine:
+
+```ruby
+gem 'rapporteur', require: 'rapporteur/engine'
+```
+
+Then execute:
 
 ```bash
 $ bundle install
@@ -70,42 +76,41 @@ for details.
 
 By default, there are no application checks that run and the status endpoint
 simply reports the current application revision and time. This is useful for a
-basic connectivity check to be watched by a third party service like Pingdom
+basic connectivity check to be watched by a third-party service like Pingdom
 for a very simple, non-critical application.
 
-You may optionally use any of the pre-defined checks (such as the ActiveRecord
+You may optionally use any of the pre-defined checks (such as the Active Record
 connection check) to expand the robustness of the status checks. Adding a check
 will execute that check each time the status endpoint is requested, so be
 somewhat wary of doing _too_ much. See more in the [Adding checks
-section](#adding-checks), below.
+section](#adding-checks) below.
 
 Further, you can define your own checks which could be custom to your
-application or environment and report their own, unique errors.  The only
+application or environment and report their own, unique errors. The only
 requirement is that the check objects are callable (respond to `#call`, like a
-Proc). See more in the [Creating custom checks
-section](#creating-custom-checks), below.
+`Proc`). See more in the [Creating custom checks
+section](#creating-custom-checks) below.
 
-### The endpoint
+### The Rails Engine Endpoint
 
-This gem provides a new, single endpoint in your application. Specifically, it
-creates a named `/status.json` route, with the "status" name. It does not match
-on any other format or variation, which isolates the pollution of your
-application routes.
+The Rails engine provided by this gem add a single endpoint to your application.
+Specifically, it creates a route for `/status.json` named `status`. It does not
+match on any other format or variation to minimize the pollution of application routes.
 
-If you'd like to link to the status endpoint from within your application (why,
-I couldn't guess), you can use a standard Rails URL helper:
+If you'd like to link to the status endpoint from within your application, you
+can use a standard Rails URL helper:
 
 ```ruby
 link_to status_path
 ```
 
-Were you already using the `/status.json` endpoint or the "status" route name?
-Hmm. Well... you just broke it.
+An existing `/status.json` route or named route called `status` will cause
+a conflict and prevent the app from booting.
 
-### Mounting the Rack app in Rails
+### Mounting the Rack App in Rails
 
 If you'd like to customize the route, you can use the provided Rack application
-and mount it to whatever path you like in your Rails application.
+instead of the Rails engine and mount it at whatever path you like.
 
 ```ruby
 Rails.application.routes.draw do
@@ -113,7 +118,7 @@ Rails.application.routes.draw do
 end
 ```
 
-### Usage without Rails (i.e. Sinatra)
+### Usage without Rails (e.g. Sinatra)
 
 If your application does not have Rails loaded, the Rails Engine logic will be
 bypassed. In this case, you must configure and run your Rapporteur reports

--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ link_to status_path
 Were you already using the `/status.json` endpoint or the "status" route name?
 Hmm. Well... you just broke it.
 
+### Mounting the Rack app in Rails
+
+If you'd like to customize the route, you can use the provided Rack application
+and mount it to whatever path you like in your Rails application.
+
+```ruby
+Rails.application.routes.draw do
+  get '/status', to: Rapporteur::App.new
+end
+```
+
 ### Usage without Rails (i.e. Sinatra)
 
 If your application does not have Rails loaded, the Rails Engine logic will be

--- a/lib/rapporteur.rb
+++ b/lib/rapporteur.rb
@@ -1,4 +1,3 @@
-require "rapporteur/engine" if defined?(Rails)
 require "rapporteur/version"
 
 # Rapporteur is a Rails Engine which provides your application with an

--- a/lib/rapporteur.rb
+++ b/lib/rapporteur.rb
@@ -5,6 +5,7 @@ require "rapporteur/version"
 # application status endpoint.
 #
 module Rapporteur
+  autoload :App, 'rapporteur/app'
   autoload :CheckList, 'rapporteur/check_list'
   autoload :Checker, 'rapporteur/checker'
   autoload :CheckerDeprecations, 'rapporteur/checker_deprecations'

--- a/lib/rapporteur/app.rb
+++ b/lib/rapporteur/app.rb
@@ -1,0 +1,15 @@
+module Rapporteur
+  class App
+    CONTENT_TYPE = 'application/json'
+
+    attr_accessor :checker
+
+    def initialize(options={})
+      self.checker = options.fetch(:checker) { Rapporteur }
+    end
+
+    def call(env)
+      [200, { 'Content-Type' => CONTENT_TYPE }, [checker.run.to_json]]
+    end
+  end
+end

--- a/lib/rapporteur/app.rb
+++ b/lib/rapporteur/app.rb
@@ -1,3 +1,8 @@
+if defined?(I18n)
+  locales_path = File.expand_path('../../../config/locales/*.yml', __FILE__)
+  I18n.load_path << Dir[locales_path]
+end
+
 module Rapporteur
   class App
     CONTENT_TYPE = 'application/json'
@@ -9,7 +14,19 @@ module Rapporteur
     end
 
     def call(env)
-      [200, { 'Content-Type' => CONTENT_TYPE }, [checker.run.to_json]]
+      status = checker.run
+
+      if status.errors.empty?
+        [200, headers, [status.to_json]]
+      else
+        [500, headers, [{ errors: status.errors }.to_json]]
+      end
+    end
+
+  private
+
+    def headers
+      { 'Content-Type' => CONTENT_TYPE }
     end
   end
 end

--- a/lib/rapporteur/engine.rb
+++ b/lib/rapporteur/engine.rb
@@ -1,3 +1,5 @@
+require 'rapporteur'
+
 module Rapporteur
   class Engine < Rails::Engine
   end

--- a/spec/requests/rack_spec.rb
+++ b/spec/requests/rack_spec.rb
@@ -1,0 +1,50 @@
+require "spec_helper"
+
+ENV["RACK_ENV"] = "test"
+
+begin
+  require "rack/test"
+
+  describe "Rack" do
+    include Rack::Test::Methods
+
+
+    def app
+      Rapporteur::App.new
+    end
+
+    before do
+      Rapporteur.add_check(Rapporteur::Checks::TimeCheck)
+    end
+
+
+    subject { get("/") ; last_response }
+
+    it 'responds with HTTP 200' do
+      expect(subject.status).to(eq(200))
+    end
+
+    it 'responds with a JSON content header' do
+      expect(subject.content_type).to(eq(Mime::JSON))
+    end
+
+    it 'responds with valid JSON' do
+      expect { JSON.parse(subject.body) }.not_to(raise_error)
+    end
+
+    it 'contains the time in ISO8601' do
+      allow(Time).to receive(:now).and_return(Time.gm(2013,8,23))
+      expect(subject).to include_status_message('time', /^2013-08-23T00:00:00(?:.000)?Z$/)
+    end
+
+    context 'the response payload' do
+      subject { get("/") ; JSON.parse(last_response.body) }
+
+      it 'does not contain errors' do
+        expect(subject).not_to(have_key('errors'))
+      end
+
+    end
+  end
+rescue LoadError
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ require 'bundler/setup'
 require 'combustion'
 
 ENV["RAILS_ENV"] ||= 'test'
+
+require 'rapporteur/engine' # the engine must be loaded before the app boots
 Combustion.initialize! :action_controller, :active_record
 
 require 'rspec/rails'


### PR DESCRIPTION
Some people may desire more customization over the application integration than the existing Rails engine affords, but currently there's no way to opt out of the engine, since it's always loaded when `Rails` is defined.

This change modifies the load sequence to prevent the engine from being automatically required. This breaks backwards compatibility, but updating the `Gemfile` will keep the existing functionality:

``` ruby
gem 'rapporteur', require: 'rapporteur/engine'
```

It also adds a Rack app can be mounted into Rails via the routes:

``` ruby
get '/status', to: Rapporteur::App.new
```
